### PR TITLE
28447466 Implement the functionality for employee to delete their GIF post

### DIFF
--- a/server/src/controllers/gifController.js
+++ b/server/src/controllers/gifController.js
@@ -33,4 +33,34 @@ export default class GifController {
       next(error);
     }
   }
+
+  /**
+   *
+   * Handles the logic to display response after gif post is deleted
+   * @static
+   * @param {*} req
+   * @param {*} res
+   * @param {*} next
+   * @returns
+   * @memberof GifController
+   */
+  static async deleteGif(req, res, next) {
+    try {
+      const { code, status, result } = await gifService.delete(req.params.gifId);
+
+      if (status === 'success') {
+        return res.status(code).json({
+          status,
+          data: result
+        });
+      }
+
+      return res.status(code).json({
+        status,
+        message: result
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
 }

--- a/server/src/helper/helper.js
+++ b/server/src/helper/helper.js
@@ -82,7 +82,6 @@ export default class Helper {
    * Handle the logic to upload image on cloudinary platform
    * @static
    * @param {String} image
-   * @param {String} tag
    * @returns Object
    * @memberof Helper
    */
@@ -99,5 +98,22 @@ export default class Helper {
       resource_type: 'auto'
     });
     return result;
+  }
+
+  /**
+   *
+   * Handles the logic to delete image on cloudinary platform
+   * @static
+   * @param {String} public_id cloudinary image name to be deleted
+   * @memberof Helper
+   */
+  static async cloudinaryDelete(public_id) {
+    const cloudinary = cloud.v2;
+    cloudinary.config({
+      cloud_name: process.env.CLOUDINARY_NAME,
+      api_key: process.env.CLOUDINARY_API_ID,
+      api_secret: process.env.CLOUDINARY_API_SECRET
+    });
+    await cloudinary.uploader.destroy(public_id);
   }
 }

--- a/server/src/middleware/gifValidation.js
+++ b/server/src/middleware/gifValidation.js
@@ -1,6 +1,23 @@
 import Joi from '@hapi/joi';
+import Gif from '../models/gif';
 
+/**
+ *
+ *
+ * @export
+ * @class GifValidation
+ */
 export default class GifValidation {
+  /**
+   *
+   * Handles the logic that check if user gif post is valid
+   * @static
+   * @param {Object} req
+   * @param {Object} res
+   * @param {*} next
+   * @returns {Object|Function}
+   * @memberof GifValidation
+   */
   static checkGifPost(req, res, next) {
     const schema = Joi.object({
       title: Joi.string().required()
@@ -19,6 +36,30 @@ export default class GifValidation {
       return res.status(422).json({
         status: 'error',
         message: 'Image is required'
+      });
+    }
+
+    return next();
+  }
+
+  /**
+   *
+   * Handles the logic to check if user is the owner of a gif post
+   * @static
+   * @param {Object} req
+   * @param {Object} res
+   * @param {*} next
+   * @returns {Object|Function}
+   * @memberof GifValidation
+   */
+  static async checkGifOwner(req, res, next) {
+    const gif = await Gif.findOne('id', req.params.gifId);
+    const { userId, isAdmin } = req.user;
+
+    if (gif.userid !== userId && !isAdmin) {
+      return res.status(401).json({
+        status: 'error',
+        message: 'You cannot perform this action. Post does not belong to you'
       });
     }
 

--- a/server/src/models/gif.js
+++ b/server/src/models/gif.js
@@ -24,4 +24,35 @@ export default class Gif {
 
     return rows[0];
   }
+
+  /**
+   *
+   * Handles the logic to retrieve a gif by an attribute from the gifs table
+   * @static
+   * @param {string} field name of the gifs' table attribute to be queried
+   * @param {string|number} value the value of the attribute
+   * @returns
+   * @memberof Gif
+   */
+  static async findOne(field, value) {
+    const sqlQuery = `SELECT * FROM gifs WHERE ${field} = $1`;
+    const { rows, rowCount } = await database.query(sqlQuery, [value]);
+
+    if (rowCount > 0) return rows[0];
+
+    return false;
+  }
+
+  /**
+   *
+   * Handles the logic to remove a gif by an attribute from the gifs table
+   * @static
+   * @param {string} field name of the gifs' table attribute to be queried
+   * @param {string|number} value the value of the attribute
+   * @memberof Gif
+   */
+  static async deleteOne(field, value) {
+    const sqlQuery = `DELETE FROM gifs WHERE ${field} = $1`;
+    await database.query(sqlQuery, [value]);
+  }
 }

--- a/server/src/routes/gif.js
+++ b/server/src/routes/gif.js
@@ -9,8 +9,9 @@ const route = express.Router();
 
 const { checkToken } = Auth;
 const { checkGifPost } = gifValidator;
-const { createGif } = gifController;
+const { createGif, deleteGif } = gifController;
 
 route.post('/', checkToken, multer, checkGifPost, createGif);
+route.delete('/:gifId', deleteGif);
 
 export default route;

--- a/server/src/routes/gif.js
+++ b/server/src/routes/gif.js
@@ -8,10 +8,10 @@ import gifController from '../controllers/gifController';
 const route = express.Router();
 
 const { checkToken } = Auth;
-const { checkGifPost } = gifValidator;
+const { checkGifPost, checkGifOwner } = gifValidator;
 const { createGif, deleteGif } = gifController;
 
 route.post('/', checkToken, multer, checkGifPost, createGif);
-route.delete('/:gifId', deleteGif);
+route.delete('/:gifId', checkToken, checkGifOwner, deleteGif);
 
 export default route;

--- a/server/src/services/gifService.js
+++ b/server/src/services/gifService.js
@@ -35,4 +35,35 @@ export default class GifService {
       }
     };
   }
+
+  /**
+   *
+   * Handles logic to delete a gif post
+   * @static
+   * @param {number} gifId
+   * @returns {object}
+   * @memberof GifService
+   */
+  static async delete(gifId) {
+    const gif = await Gif.findOne('id', gifId);
+
+    if (!gif) {
+      return {
+        code: 404,
+        status: 'error',
+        result: 'Gif post cannot be found'
+      };
+    }
+
+    await Gif.deleteOne('id', gifId);
+
+    return {
+      code: 200,
+      status: 'success',
+      result: {
+        gifId,
+        message: 'GIF post successfully deleted'
+      }
+    };
+  }
 }

--- a/server/src/services/gifService.js
+++ b/server/src/services/gifService.js
@@ -1,7 +1,7 @@
 import Gif from '../models/gif';
 import helper from '../helper/helper';
 
-const { cloudinaryUpload } = helper;
+const { cloudinaryUpload, cloudinaryDelete } = helper;
 
 /**
  *
@@ -55,6 +55,10 @@ export default class GifService {
       };
     }
 
+    const splitImageUrl = gif.imageurl.split('/');
+    const public_id = splitImageUrl[splitImageUrl.length - 1].split('.')[0];
+
+    await cloudinaryDelete(public_id);
     await Gif.deleteOne('id', gifId);
 
     return {

--- a/server/src/services/gifService.js
+++ b/server/src/services/gifService.js
@@ -65,7 +65,7 @@ export default class GifService {
       code: 200,
       status: 'success',
       result: {
-        gifId,
+        gifId: parseInt(gifId, 10),
         message: 'GIF post successfully deleted'
       }
     };

--- a/server/src/tests/gif.test.js
+++ b/server/src/tests/gif.test.js
@@ -11,6 +11,23 @@ chai.use(chaiHttp);
 
 describe('Test Suite For Gif Endpoints', () => {
   let employeeToken;
+  let employee2Token;
+  let newGifId;
+
+  before(done => {
+    chai
+      .request(server)
+      .post('/api/v1/auth/signin')
+      .send({
+        email: 'bidemikarunwi@gmail.com',
+        password: 'secret'
+      })
+      .end((err, res) => {
+        const { token } = res.body.data;
+        employee2Token = token;
+        done();
+      });
+  });
 
   before(done => {
     chai
@@ -23,6 +40,20 @@ describe('Test Suite For Gif Endpoints', () => {
       .end((err, res) => {
         const { token } = res.body.data;
         employeeToken = token;
+        done();
+      });
+  });
+
+  before(done => {
+    chai
+      .request(server)
+      .post('/api/v1/gifs')
+      .set('Authorization', `Bearer ${employeeToken}`)
+      .type('form')
+      .attach('image', './server/src/tests/images/weekend.gif')
+      .field('title', 'weekend is approaching')
+      .end((err, res) => {
+        newGifId = res.body.data.gifId;
         done();
       });
   });
@@ -104,6 +135,45 @@ describe('Test Suite For Gif Endpoints', () => {
           res.status.should.be.eql(422);
           res.body.status.should.be.eql('error');
           res.body.message.should.be.a('string');
+          done();
+        });
+    });
+  });
+  describe('DELETE /api/v1/gifs/<:gifId>', () => {
+    it('should delete gif image post if gifId and token exist', done => {
+      chai
+        .request(server)
+        .delete(`/api/v1/gifs/${newGifId}`)
+        .set('Authorization', `Bearer ${employeeToken}`)
+        .end((err, res) => {
+          res.status.should.be.eql(200);
+          res.body.status.should.be.eql('success');
+          res.body.data.message.should.be.eql('GIF post successfully deleted');
+          res.body.data.gifId.should.be.a('number');
+          done();
+        });
+    });
+    it('should return error if no token is provided', done => {
+      chai
+        .request(server)
+        .delete(`/api/v1/gifs/${newGifId}`)
+        .set('Authorization', '')
+        .end((err, res) => {
+          res.status.should.be.eql(401);
+          res.body.status.should.be.eql('error');
+          res.body.data.message.should.be.eql('string');
+          done();
+        });
+    });
+    it('should return error if user try to delete colleague gif post', done => {
+      chai
+        .request(server)
+        .delete(`/api/v1/gifs/${newGifId}`)
+        .set('Authorization', `Bearer ${employee2Token}`)
+        .end((err, res) => {
+          res.status.should.be.eql(401);
+          res.body.status.should.be.eql('error');
+          res.body.data.message.should.be.eql('string');
           done();
         });
     });

--- a/server/src/tests/gif.test.js
+++ b/server/src/tests/gif.test.js
@@ -13,6 +13,7 @@ describe('Test Suite For Gif Endpoints', () => {
   let employeeToken;
   let employee2Token;
   let newGifId;
+  let newGifId2;
 
   before(done => {
     chai
@@ -54,6 +55,20 @@ describe('Test Suite For Gif Endpoints', () => {
       .field('title', 'weekend is approaching')
       .end((err, res) => {
         newGifId = res.body.data.gifId;
+        done();
+      });
+  });
+
+  before(done => {
+    chai
+      .request(server)
+      .post('/api/v1/gifs')
+      .set('Authorization', `Bearer ${employeeToken}`)
+      .type('form')
+      .attach('image', './server/src/tests/images/weekend.gif')
+      .field('title', 'weekend is approaching')
+      .end((err, res) => {
+        newGifId2 = res.body.data.gifId;
         done();
       });
   });
@@ -156,24 +171,36 @@ describe('Test Suite For Gif Endpoints', () => {
     it('should return error if no token is provided', done => {
       chai
         .request(server)
-        .delete(`/api/v1/gifs/${newGifId}`)
+        .delete(`/api/v1/gifs/${newGifId2}`)
         .set('Authorization', '')
         .end((err, res) => {
           res.status.should.be.eql(401);
           res.body.status.should.be.eql('error');
-          res.body.data.message.should.be.eql('string');
+          res.body.message.should.be.a('string');
+          done();
+        });
+    });
+    it('should return error if gifId does not exist', done => {
+      chai
+        .request(server)
+        .delete(`/api/v1/gifs/100000`)
+        .set('Authorization', `Bearer ${employeeToken}`)
+        .end((err, res) => {
+          res.status.should.be.eql(401);
+          res.body.status.should.be.eql('error');
+          res.body.message.should.be.a('string');
           done();
         });
     });
     it('should return error if user try to delete colleague gif post', done => {
       chai
         .request(server)
-        .delete(`/api/v1/gifs/${newGifId}`)
+        .delete(`/api/v1/gifs/${newGifId2}`)
         .set('Authorization', `Bearer ${employee2Token}`)
         .end((err, res) => {
           res.status.should.be.eql(401);
           res.body.status.should.be.eql('error');
-          res.body.data.message.should.be.eql('string');
+          res.body.message.should.be.a('string');
           done();
         });
     });

--- a/server/src/tests/user.test.js
+++ b/server/src/tests/user.test.js
@@ -192,7 +192,7 @@ describe('Test Suite For User Endpoints', () => {
         .send({
           firstName: '',
           lastName: 'bull',
-          email: 'johnbull@gmail.com',
+          email: 'johnbul@gmail.com',
           password: 'secret',
           gender: 'male',
           jobRole: 'accountant',
@@ -214,7 +214,7 @@ describe('Test Suite For User Endpoints', () => {
         .send({
           firstName: 'john',
           lastName: '',
-          email: 'johnbull@gmail.com',
+          email: 'johnbul@gmail.com',
           password: 'secret',
           gender: 'male',
           jobRole: 'accountant',
@@ -302,7 +302,7 @@ describe('Test Suite For User Endpoints', () => {
         .send({
           firstName: 'john',
           lastName: 'bull',
-          email: 'johnbull@gmail.com',
+          email: 'johnbul@gmail.com',
           password: '',
           gender: 'male',
           jobRole: 'accountant',
@@ -324,7 +324,7 @@ describe('Test Suite For User Endpoints', () => {
         .send({
           firstName: 'john',
           lastName: 'bull',
-          email: 'johnbull@gmail.com',
+          email: 'johnbul@gmail.com',
           password: 'secre',
           gender: 'male',
           jobRole: 'accountant',
@@ -346,7 +346,7 @@ describe('Test Suite For User Endpoints', () => {
         .send({
           firstName: 'john',
           lastName: 'bull',
-          email: 'johnbull@gmail.com',
+          email: 'johnbul@gmail.com',
           password: 'secret',
           gender: '',
           jobRole: 'accountant',
@@ -368,7 +368,7 @@ describe('Test Suite For User Endpoints', () => {
         .send({
           firstName: 'john',
           lastName: 'bull',
-          email: 'johnbull@gmail.com',
+          email: 'johnbul@gmail.com',
           password: 'secret',
           gender: 'male',
           jobRole: '',
@@ -390,7 +390,7 @@ describe('Test Suite For User Endpoints', () => {
         .send({
           firstName: 'john',
           lastName: 'bull',
-          email: 'johnbull@gmail.com',
+          email: 'johnbul@gmail.com',
           password: 'secret',
           gender: 'male',
           jobRole: 'accountant',
@@ -412,7 +412,7 @@ describe('Test Suite For User Endpoints', () => {
         .send({
           firstName: 'john',
           lastName: 'bull',
-          email: 'johnbull@gmail.com',
+          email: 'johnbul@gmail.com',
           password: 'secret',
           gender: 'male',
           jobRole: 'accountant',


### PR DESCRIPTION
#### What does this PR do?
- Implement the functionality for an employee to delete their gif post

#### Description of Task to be completed?
- write the test suite for an employee to delete their gif post
- add the logic to delete gif post from the database
- add the logic to delete the image from Cloudinary
- protect the route to allow only the owner to delete their post
- make failing test to pass
- finish[  #11 ]

#### How should this be manually tested?
- Clone the repository using git clone `https://github.com/an-apluss/teamwork.git`  in your terminal
- run `npm install` on your terminal
- run `npm run migrations` on your terminal to create required tables for the application
- run `npm start` on your terminal to start the server
- make a `delete` request on `https://web-teamwork.herokuapp.com/api/v1/gifs/2` with the necessary body request using postman
- ensure you set the request header like below
````
key                                Value
Authorization              Bearer wwedncndhd.ckd.--cmdmksks...
````
- you should see a response like below 
````
{
   "status": "success",
   "data": {
         "gifId": 2,
        "message": "GIF post successfully deleted"
   }
}
````
#### Any background context you want to provide?
- Ensure that you provide value for the list of environment variable in the `.env.example`  file and rename to `.env`
- You can only delete gif post that belongs to you

#### What are the relevant issue stories?
- Github Project Board Card Link - ( [#28447466](https://github.com/an-apluss/teamwork/projects/1#card-28447466) )

#### Screenshots(if appropriate)
-N/A
